### PR TITLE
refactor: adjust zip codes to strings. Migration required

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -3,5 +3,5 @@ class Application < ApplicationRecord
   has_many :pets, through: :pet_applications
 
   validates :name, :street_address, :city, :state, :description, :status, presence: true
-  validates :zip_code, presence: true, numericality: true, length: { is: 5 }
+  validates :zip_code, presence: true, length: { is: 5 }
 end

--- a/db/migrate/20230524165441_change_zip_codeto_string.rb
+++ b/db/migrate/20230524165441_change_zip_codeto_string.rb
@@ -1,0 +1,5 @@
+class ChangeZipCodetoString < ActiveRecord::Migration[7.0]
+  def change
+    change_column :applications, :zip_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_21_144356) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_24_165441) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_21_144356) do
     t.string "street_address"
     t.string "city"
     t.string "state"
-    t.integer "zip_code"
+    t.string "zip_code"
     t.string "description"
     t.string "pets"
     t.string "status", default: "In Progress"

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Application, type: :model do
     it { should validate_presence_of :street_address}
     it { should validate_presence_of :city}
     it { should validate_presence_of :state}
-    it { should validate_numericality_of :zip_code}
+    it { should validate_presence_of :zip_code}
+    it { should validate_length_of(:zip_code).is_equal_to(5) }
     it { should validate_presence_of :description}
     it { should validate_presence_of :status}
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,17 +53,17 @@ def admin_test_data
   @pet_5 = @shelter_3.pets.create!(adoptable: true, age: 4, breed: "tabby", name: "Pepper")
 
   @application_1 = Application.create!(name: "Bob", street_address: "1234 Southeast St",
-  city: "San Francisco", state: "CA", zip_code: 12345,
+  city: "San Francisco", state: "CA", zip_code: "2234R",
   description: "Wants a dog", status: "Pending")
   @application_2 = Application.create!(name: "Sally", street_address: "4321 Bridge Way",
-  city: "San Francisco", state: "CA", zip_code: 54321,
+  city: "San Francisco", state: "CA", zip_code: "AR321",
   description: "Would like a siamese cat", status: "Pending")
 
   @application_3 = Application.create!(name: "Fred", street_address: "376 Monroe St",
-  city: "Los Angeles", state: "CA", zip_code: 67890,
+  city: "Los Angeles", state: "CA", zip_code: "67890",
   description: "My wife really wants this cat", status: "In Progress")
   @application_5 = Application.create!(name: "Jimbo", street_address: "45865 Turnaround St",
-  city: "NYC", state: "NY", zip_code: 84930,
+  city: "NYC", state: "NY", zip_code: "84930",
   description: "I want a big ol dog", status: "Pending")
 
   PetApplication.create!(pet: @pet_2, application: @application_1)


### PR DESCRIPTION
This PR contains refactors to our zip code attribute. Created a migration to change the zip code to a string to contains letters and numbers.
Validations are also updated.